### PR TITLE
データベースに献立情報を追加

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,9 @@
 rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if false;
+    match /foods/{foodId} {
+      allow read: if true;
+      allow write: if request.auth.uid != null;
     }
   }
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -16,6 +16,11 @@ const routes: Routes = [
     loadChildren: () =>
       import('./food-list/food-list.module').then((m) => m.FoodListModule),
   },
+  {
+    path: 'editor',
+    loadChildren: () =>
+      import('./editor/editor.module').then((m) => m.EditorModule),
+  },
 ];
 
 @NgModule({

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { EmailDialogComponent } from './email-dialog/email-dialog.component';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 
 @NgModule({
   declarations: [
@@ -57,6 +58,7 @@ import { ReactiveFormsModule, FormsModule } from '@angular/forms';
     MatFormFieldModule,
     ReactiveFormsModule,
     FormsModule,
+    MatSnackBarModule,
   ],
   providers: [{ provide: REGION, useValue: 'asia-northeast1' }],
   bootstrap: [AppComponent],

--- a/src/app/editor/editor-routing.module.ts
+++ b/src/app/editor/editor-routing.module.ts
@@ -1,0 +1,17 @@
+import { NgModule } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+import { EditorComponent } from './editor/editor.component';
+
+const routes: Routes = [
+  {
+    path: '',
+    pathMatch: 'full',
+    component: EditorComponent,
+  },
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule],
+})
+export class EditorRoutingModule {}

--- a/src/app/editor/editor.module.ts
+++ b/src/app/editor/editor.module.ts
@@ -1,0 +1,23 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+import { EditorRoutingModule } from './editor-routing.module';
+import { EditorComponent } from './editor/editor.component';
+import { MatInputModule } from '@angular/material/input';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatButtonModule } from '@angular/material/button';
+
+@NgModule({
+  declarations: [EditorComponent],
+  imports: [
+    CommonModule,
+    EditorRoutingModule,
+    MatInputModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatButtonModule,
+  ],
+})
+export class EditorModule {}

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -1,0 +1,27 @@
+<div class="container">
+  <form [formGroup]="form" (ngSubmit)="submit()">
+    <mat-form-field>
+      <mat-label>メニュー名</mat-label>
+      <input
+        type="text"
+        matInput
+        formControlName="name"
+        autocomplete="off"
+        required
+      />
+    </mat-form-field>
+    <mat-form-field>
+      <mat-label>画像URL</mat-label>
+      <input
+        type="text"
+        matInput
+        formControlName="image"
+        autocomplete="off"
+        required
+      />
+    </mat-form-field>
+    <button mat-raised-button color="primary" [disabled]="form.invalid">
+      firestoreに送信
+    </button>
+  </form>
+</div>

--- a/src/app/editor/editor/editor.component.scss
+++ b/src/app/editor/editor/editor.component.scss
@@ -1,0 +1,7 @@
+.container {
+  height: 450px;
+}
+
+mat-form-field {
+  width: 100%;
+}

--- a/src/app/editor/editor/editor.component.spec.ts
+++ b/src/app/editor/editor/editor.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditorComponent } from './editor.component';
+
+describe('EditorComponent', () => {
+  let component: EditorComponent;
+  let fixture: ComponentFixture<EditorComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [EditorComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(EditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -1,0 +1,27 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+import { FoodService } from 'src/app/services/food.service';
+
+@Component({
+  selector: 'app-editor',
+  templateUrl: './editor.component.html',
+  styleUrls: ['./editor.component.scss'],
+})
+export class EditorComponent implements OnInit {
+  form = this.fb.group({
+    name: ['', Validators.required],
+    image: ['', Validators.required],
+  });
+
+  constructor(private fb: FormBuilder, private foodService: FoodService) {}
+
+  ngOnInit(): void {}
+
+  submit() {
+    const formData = this.form.value;
+    this.foodService.createFood({
+      name: formData.name,
+      image: formData.image,
+    });
+  }
+}

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -34,4 +34,5 @@
   <button mat-menu-item (click)="logout()" *ngIf="user$ | async">
     ログアウト
   </button>
+  <button mat-menu-item routerLink="/editor">管理者画面</button>
 </mat-menu>

--- a/src/app/interfaces/food.ts
+++ b/src/app/interfaces/food.ts
@@ -1,0 +1,4 @@
+export interface Food {
+  name: string;
+  image: string;
+}

--- a/src/app/services/food.service.spec.ts
+++ b/src/app/services/food.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { FoodService } from './food.service';
+
+describe('FoodService', () => {
+  let service: FoodService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(FoodService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/food.service.ts
+++ b/src/app/services/food.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import { Food } from '../interfaces/food';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class FoodService {
+  constructor(private db: AngularFirestore, private snackBar: MatSnackBar) {}
+
+  createFood(food: Food) {
+    const id = this.db.createId();
+    return this.db
+      .doc(`foods/${id}`)
+      .set(food)
+      .then(() => {
+        this.snackBar.open('メニューを作成しました！', null, {
+          duration: 3000,
+        });
+      });
+  }
+}


### PR DESCRIPTION
fix #35 
以下のように実装しました。
ご確認のほどお願いします。
## 作業内容
- 管理者画面追加
- firestoreに献立情報追加
画像情報は一旦String型のデモのURLにしました。
- firestore.rule変更

<img width="413" alt="スクリーンショット 2020-05-17 14 25 14" src="https://user-images.githubusercontent.com/63761544/82136570-46bcc680-984a-11ea-87d2-605104e68dbf.png">
