### PR TITLE
献立詳細画面実装

### DIFF
--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -23,9 +23,10 @@ export class EditorComponent implements OnInit {
       .createFood({
         name: formData.name,
         image: formData.image,
+        id: this.foodService.id,
       })
       .then(() => {
-        this.form.reset();
+        this.form.controls.name.reset();
       });
   }
 }

--- a/src/app/food-detail/food-detail.component.html
+++ b/src/app/food-detail/food-detail.component.html
@@ -1,0 +1,11 @@
+<div class="container">
+  <div *ngIf="food$ | async as food">
+    <h1>{{ food.name }}</h1>
+    <img [src]="food.image" alt="" />
+    <p>
+      Lorem ipsum dolor sit amet consectetur adipisicing elit. Officiis, qui.
+      Soluta repellat doloribus quam, aperiam repudiandae veritatis beatae non
+      animi voluptatum enim optio suscipit asperiores eius et eum pariatur quae!
+    </p>
+  </div>
+</div>

--- a/src/app/food-detail/food-detail.component.scss
+++ b/src/app/food-detail/food-detail.component.scss
@@ -1,0 +1,3 @@
+h1 {
+  font-size: 24px;
+}

--- a/src/app/food-detail/food-detail.component.spec.ts
+++ b/src/app/food-detail/food-detail.component.spec.ts
@@ -1,0 +1,24 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { FoodDetailComponent } from './food-detail.component';
+
+describe('FoodDetailComponent', () => {
+  let component: FoodDetailComponent;
+  let fixture: ComponentFixture<FoodDetailComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [FoodDetailComponent],
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(FoodDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/food-detail/food-detail.component.ts
+++ b/src/app/food-detail/food-detail.component.ts
@@ -1,0 +1,29 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { FoodService } from '../services/food.service';
+import { Observable } from 'rxjs';
+import { Food } from '../interfaces/food';
+import { switchMap } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-food-detail',
+  templateUrl: './food-detail.component.html',
+  styleUrls: ['./food-detail.component.scss'],
+})
+export class FoodDetailComponent implements OnInit {
+  food$: Observable<Food>;
+
+  constructor(
+    private route: ActivatedRoute,
+    private foodService: FoodService
+  ) {}
+
+  ngOnInit(): void {
+    this.food$ = this.route.paramMap.pipe(
+      switchMap((prams) => {
+        const id = prams.get('detail');
+        return this.foodService.getFoodId(id);
+      })
+    );
+  }
+}

--- a/src/app/food-list/food-list-routing.module.ts
+++ b/src/app/food-list/food-list-routing.module.ts
@@ -1,12 +1,17 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { FoodListComponent } from './food-list/food-list.component';
+import { FoodDetailComponent } from '../food-detail/food-detail.component';
 
 const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
     component: FoodListComponent,
+  },
+  {
+    path: ':detail',
+    component: FoodDetailComponent,
   },
 ];
 

--- a/src/app/food-list/food-list.module.ts
+++ b/src/app/food-list/food-list.module.ts
@@ -3,9 +3,10 @@ import { CommonModule } from '@angular/common';
 
 import { FoodListRoutingModule } from './food-list-routing.module';
 import { FoodListComponent } from './food-list/food-list.component';
+import { FoodDetailComponent } from '../food-detail/food-detail.component';
 
 @NgModule({
-  declarations: [FoodListComponent],
+  declarations: [FoodListComponent, FoodDetailComponent],
   imports: [CommonModule, FoodListRoutingModule],
 })
 export class FoodListModule {}

--- a/src/app/food-list/food-list/food-list.component.html
+++ b/src/app/food-list/food-list/food-list.component.html
@@ -1,7 +1,10 @@
 <div class="container">
   <h1>メニュー一覧</h1>
   <div class="grid">
-    <div *ngFor="let food of foods$ | async">
+    <div
+      *ngFor="let food of foods$ | async"
+      routerLink="/food-list/{{ food.id }}"
+    >
       <div class="food">
         <img class="food__img" [src]="food.image" alt="" />
         <p class="food__name">{{ food.name }}</p>

--- a/src/app/interfaces/food.ts
+++ b/src/app/interfaces/food.ts
@@ -1,4 +1,5 @@
 export interface Food {
   name: string;
   image: string;
+  id: string;
 }

--- a/src/app/services/food.service.ts
+++ b/src/app/services/food.service.ts
@@ -8,12 +8,13 @@ import { Observable } from 'rxjs';
   providedIn: 'root',
 })
 export class FoodService {
+  id = this.db.createId();
+
   constructor(private db: AngularFirestore, private snackBar: MatSnackBar) {}
 
   createFood(food: Food) {
-    const id = this.db.createId();
     return this.db
-      .doc(`foods/${id}`)
+      .doc(`foods/${this.id}`)
       .set(food)
       .then(() => {
         this.snackBar.open('メニューを作成しました！', null, {
@@ -24,5 +25,9 @@ export class FoodService {
 
   getFood(): Observable<Food[]> {
     return this.db.collection<Food>('foods').valueChanges();
+  }
+
+  getFoodId(id: string): Observable<Food> {
+    return this.db.doc<Food>(`foods/${id}`).valueChanges();
   }
 }


### PR DESCRIPTION
fix #39 
以下のように実装しました。
ご確認のほどお願いします。
## 作業内容
- Food Interfaceの変更
firestoreに献立情報を追加する際に、作成されたドキュメントIDをFood InterfaceのidにString型で追加するようにしました。
- 献立詳細画面追加
- 動的URLの実装

![0489049d0d0aace8bca37bf329caef41](https://user-images.githubusercontent.com/63761544/82285561-aba52780-99d6-11ea-885e-1b2b0b27daf1.gif)
