### PR TITLE
firestoreのデータを一週間の献立に表示

### DIFF
--- a/src/app/food-list/food-list/food-list.component.ts
+++ b/src/app/food-list/food-list/food-list.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FoodService } from 'src/app/services/food.service';
+import { Observable } from 'rxjs';
+import { Food } from 'src/app/interfaces/food';
 
 @Component({
   selector: 'app-food-list',
@@ -7,7 +9,7 @@ import { FoodService } from 'src/app/services/food.service';
   styleUrls: ['./food-list.component.scss'],
 })
 export class FoodListComponent implements OnInit {
-  foods$ = this.foodService.getFood();
+  foods$: Observable<Food[]> = this.foodService.getFood();
 
   constructor(private foodService: FoodService) {}
 

--- a/src/app/menu/menu/menu.component.html
+++ b/src/app/menu/menu/menu.component.html
@@ -3,29 +3,29 @@
     <div *ngFor="let day of days">
       <h1>{{ day }}曜日</h1>
       <div class="menu-grid">
-        <div class="food">
+        <div class="food" *ngIf="dayFood$ | async as dayFood">
           <img
             class="food__img"
-            src="https://dummyimage.com/150x150/F0FFF0.png"
+            [src]="dayFood.image"
             alt=""
           />
-          <p class="food__name">foodName</p>
+          <p class="food__name">{{dayFood.name}}</p>
         </div>
-        <div class="food">
+        <div class="food" *ngIf="dayFood$ | async as dayFood">
           <img
             class="food__img"
-            src="https://dummyimage.com/150x150/F0FFF0.png"
+            [src]="dayFood.image"
             alt=""
           />
-          <p class="food__name">foodName</p>
+          <p class="food__name">{{dayFood.name}}</p>
         </div>
-        <div class="food">
+        <div class="food" *ngIf="dayFood$ | async as dayFood">
           <img
             class="food__img"
-            src="https://dummyimage.com/150x150/F0FFF0.png"
+            [src]="dayFood.image"
             alt=""
           />
-          <p class="food__name">foodName</p>
+          <p class="food__name">{{dayFood.name}}</p>
         </div>
       </div>
     </div>

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -1,4 +1,7 @@
 import { Component, OnInit } from '@angular/core';
+import { FoodService } from 'src/app/services/food.service';
+import { Observable } from 'rxjs';
+import { Food } from 'src/app/interfaces/food';
 
 @Component({
   selector: 'app-menu',
@@ -6,9 +9,13 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./menu.component.scss'],
 })
 export class MenuComponent implements OnInit {
-  days = ['月', '火', '水', '木', '金', '土', '日'];
 
-  constructor() {}
+  days = ['月', '火', '水', '木', '金', '土', '日'];
+  dayFood$: Observable<Food> = this.foodService.getDayFood();
+
+  constructor(
+    private foodService: FoodService
+  ) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/services/food.service.ts
+++ b/src/app/services/food.service.ts
@@ -3,6 +3,7 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Food } from '../interfaces/food';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root',
@@ -29,5 +30,14 @@ export class FoodService {
 
   getFoodId(id: string): Observable<Food> {
     return this.db.doc<Food>(`foods/${id}`).valueChanges();
+  }
+
+  getDayFood(): Observable<Food> {
+    return this.db.collection<Food>('foods').valueChanges()
+      .pipe(
+        map(foods => {
+          return foods[Math.floor(Math.random() * foods.length)];
+        })
+      );
   }
 }


### PR DESCRIPTION
fix #40 
以下のように実装しました。
ご確認のほどお願いします。
## 作業内容
- ランダムなメニューを献立画面に表示
後々には朝昼晩のメニューを自分で選択して献立に組み込めるようにしたいので、現段階ではメニュー一覧から三つ並べてます。

<img width="387" alt="スクリーンショット 2020-05-22 13 46 31" src="https://user-images.githubusercontent.com/63761544/82632285-c1af2400-9c32-11ea-9c11-ef9ff3097b58.png">

