### PR TITLE
曜日ごとの献立表示

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -12,5 +12,9 @@ service cloud.firestore {
       allow read: if true;
       allow write: if isAuthenticated()
     }
+    match /userMenus/{myMenuId} {
+      allow read: if true;
+      allow write: if isAuthenticated()
+    }
   }
 }

--- a/functions/src/interfaces/my-menu.ts
+++ b/functions/src/interfaces/my-menu.ts
@@ -1,0 +1,38 @@
+import { Food } from './food';
+
+export interface DayMenu {
+  breakfastId: string;
+  lunchId: string;
+  dinnerId: string;
+}
+
+export interface MyMenu {
+  day: {
+    sunday: DayMenu;
+    monday: DayMenu;
+    tuesday: DayMenu;
+    wednesday: DayMenu;
+    thursday: DayMenu;
+    friday: DayMenu;
+    saturday: DayMenu;
+  };
+  creatorId: string;
+  myMenuId: string;
+}
+
+export interface DayMenuWithFood {
+  breakfast: Food;
+  lunch: Food;
+  dinner: Food;
+  dayOfWeek: string;
+}
+
+export interface MyMenuWithFood {
+  sundayFood: DayMenuWithFood;
+  mondayFood: DayMenuWithFood;
+  tuesdayFood: DayMenuWithFood;
+  wednesdayFood: DayMenuWithFood;
+  thursdayFood: DayMenuWithFood;
+  fridayFood: DayMenuWithFood;
+  saturdayFood: DayMenuWithFood;
+}

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -28,15 +28,13 @@ export class EditorComponent implements OnInit {
       .createFood({
         name: formData.name,
         image: formData.image,
-        recipe: 'a',
-      })
-      .then(() => {
-        this.form.controls.name.reset();
+        recipe: '',
       })
       .then(() => {
         this.snackBar.open('firestoreに追加しました！', null, {
           duration: 3000,
         });
+        this.form.controls.name.reset();
       });
   }
 }

--- a/src/app/food-detail/food-detail.component.ts
+++ b/src/app/food-detail/food-detail.component.ts
@@ -22,7 +22,7 @@ export class FoodDetailComponent implements OnInit {
     this.food$ = this.route.paramMap.pipe(
       switchMap((prams) => {
         const id = prams.get('detail');
-        return this.foodService.getFoodId(id);
+        return this.foodService.getFoodById(id);
       })
     );
   }

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,26 +1,22 @@
 <div class="container">
-  <h1>これを食え</h1>
-  <div class="food">
-    <div class="breakfast">
-      <img
-        src="/assets/images/ben-kolde-FFqNATH27EM-unsplash.jpg"
-        alt="デモ画像"
-      />
-      <label>朝食</label>
-    </div>
-    <div class="lunch">
-      <img
-        src="/assets/images/fran-hogan-ksCum0SeHg0-unsplash.jpg"
-        alt="デモ画像"
-      />
-      <label>昼食</label>
-    </div>
-    <div class="dinner">
-      <img
-        src="/assets/images/keri-liwi-c3mFafsFz2w-unsplash.jpg"
-        alt="デモ画像"
-      />
-      <label>夕食</label>
+  <div class="food" *ngIf="todayMenu$ | async as todayMenu">
+    <h1>{{ todayMenu.dayOfWeek }}曜日の献立</h1>
+    <div class="grid">
+      <div
+        class="breakfast"
+        routerLink="/menu/{{ todayMenu.breakfast.foodId }}"
+      >
+        <img [src]="todayMenu.breakfast.image" alt="デモ画像" />
+        <label>朝食「{{ todayMenu.breakfast.name }}」</label>
+      </div>
+      <div class="lunch" routerLink="/menu/{{ todayMenu.lunch.foodId }}">
+        <img [src]="todayMenu.lunch.image" alt="デモ画像" />
+        <label>昼食「{{ todayMenu.lunch.name }}」</label>
+      </div>
+      <div class="dinner" routerLink="/menu/{{ todayMenu.dinner.foodId }}">
+        <img [src]="todayMenu.dinner.image" alt="デモ画像" />
+        <label>夕食「{{ todayMenu.dinner.name }}」</label>
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -1,11 +1,13 @@
-h1 {
-  margin-top: 0;
-}
-
-.food {
+.grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 24px;
+}
+
+img {
+  display: block;
+  margin: 0 auto 8px;
+  border: 1px solid rgba(black, 0.32);
 }
 
 label {

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -1,4 +1,10 @@
 import { Component, OnInit } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { DayMenuWithFood } from '@interfaces/my-menu';
+import { MyMenuService } from 'src/app/services/my-menu.service';
+import { AuthService } from 'src/app/services/auth.service';
+import { switchMap } from 'rxjs/operators';
+import { User } from '@interfaces/user';
 
 @Component({
   selector: 'app-home',
@@ -6,7 +12,20 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  constructor() {}
+  todayMenu$: Observable<DayMenuWithFood | null> = this.authService.afUser$.pipe(
+    switchMap((user: User) => {
+      if (user) {
+        return this.myMenuService.getTodayMenu(user.uid);
+      } else {
+        return of(null);
+      }
+    })
+  );
+
+  constructor(
+    private myMenuService: MyMenuService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/menu/menu-routing.module.ts
+++ b/src/app/menu/menu-routing.module.ts
@@ -1,12 +1,17 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { MenuComponent } from './menu/menu.component';
+import { FoodDetailComponent } from '../food-detail/food-detail.component';
 
 const routes: Routes = [
   {
     path: '',
     pathMatch: 'full',
     component: MenuComponent,
+  },
+  {
+    path: ':detail',
+    component: FoodDetailComponent,
   },
 ];
 

--- a/src/app/menu/menu/menu.component.html
+++ b/src/app/menu/menu/menu.component.html
@@ -1,31 +1,19 @@
 <div class="container">
   <div class="grid">
-    <div *ngFor="let day of days">
-      <h1>{{ day }}曜日</h1>
+    <div *ngFor="let weekMenu of weekMenu$ | async">
+      <h1>{{ weekMenu.dayOfWeek }}曜日</h1>
       <div class="menu-grid">
-        <div class="food" *ngIf="dayFood$ | async as dayFood">
-          <img
-            class="food__img"
-            [src]="dayFood.image"
-            alt=""
-          />
-          <p class="food__name">{{dayFood.name}}</p>
+        <div class="food" routerLink="/menu/{{ weekMenu.breakfast.foodId }}">
+          <img class="food__img" [src]="weekMenu.breakfast.image" alt="" />
+          <p class="food__name">{{ weekMenu.breakfast.name }}</p>
         </div>
-        <div class="food" *ngIf="dayFood$ | async as dayFood">
-          <img
-            class="food__img"
-            [src]="dayFood.image"
-            alt=""
-          />
-          <p class="food__name">{{dayFood.name}}</p>
+        <div class="food" routerLink="/menu/{{ weekMenu.lunch.foodId }}">
+          <img class="food__img" [src]="weekMenu.lunch.image" alt="" />
+          <p class="food__name">{{ weekMenu.lunch.name }}</p>
         </div>
-        <div class="food" *ngIf="dayFood$ | async as dayFood">
-          <img
-            class="food__img"
-            [src]="dayFood.image"
-            alt=""
-          />
-          <p class="food__name">{{dayFood.name}}</p>
+        <div class="food" routerLink="/menu/{{ weekMenu.dinner.foodId }}">
+          <img class="food__img" [src]="weekMenu.dinner.image" alt="" />
+          <p class="food__name">{{ weekMenu.dinner.name }}</p>
         </div>
       </div>
     </div>

--- a/src/app/menu/menu/menu.component.ts
+++ b/src/app/menu/menu/menu.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit } from '@angular/core';
-import { FoodService } from 'src/app/services/food.service';
-import { Observable } from 'rxjs';
-import { Food } from '@interfaces/food';
+import { MyMenuService } from 'src/app/services/my-menu.service';
+import { Observable, of } from 'rxjs';
+import { DayMenuWithFood, MyMenuWithFood } from '@interfaces/my-menu';
+import { AuthService } from 'src/app/services/auth.service';
+import { User } from '@interfaces/user';
+import { switchMap, map } from 'rxjs/operators';
 
 @Component({
   selector: 'app-menu',
@@ -9,10 +12,34 @@ import { Food } from '@interfaces/food';
   styleUrls: ['./menu.component.scss'],
 })
 export class MenuComponent implements OnInit {
-  days = ['月', '火', '水', '木', '金', '土', '日'];
-  dayFood$: Observable<Food> = this.foodService.getDayFood();
+  weekMenu$: Observable<
+    DayMenuWithFood[] | null
+  > = this.authService.afUser$.pipe(
+    switchMap((user: User) => {
+      if (user) {
+        return this.myMenuService.getMyMenuWithFood(user.uid);
+      } else {
+        return of(null);
+      }
+    }),
+    map((myMenuWithFood: MyMenuWithFood | null) => {
+      const weekMenu: DayMenuWithFood[] = [
+        myMenuWithFood.sundayFood,
+        myMenuWithFood.mondayFood,
+        myMenuWithFood.tuesdayFood,
+        myMenuWithFood.wednesdayFood,
+        myMenuWithFood.thursdayFood,
+        myMenuWithFood.fridayFood,
+        myMenuWithFood.saturdayFood,
+      ];
+      return weekMenu;
+    })
+  );
 
-  constructor(private foodService: FoodService) {}
+  constructor(
+    private myMenuService: MyMenuService,
+    private authService: AuthService
+  ) {}
 
   ngOnInit(): void {}
 }

--- a/src/app/my-menu/my-menu/my-menu.component.html
+++ b/src/app/my-menu/my-menu/my-menu.component.html
@@ -6,15 +6,33 @@
       <div [formGroupName]="i">
         <mat-form-field>
           <mat-label>朝食</mat-label>
-          <input type="text" matInput formControlName="breakfast" />
+          <input
+            type="text"
+            matInput
+            formControlName="breakfast"
+            autocomplete="off"
+          />
+          <mat-error>必須入力です</mat-error>
         </mat-form-field>
         <mat-form-field>
           <mat-label>昼食</mat-label>
-          <input type="text" matInput formControlName="lunch" />
+          <input
+            type="text"
+            matInput
+            formControlName="lunch"
+            autocomplete="off"
+          />
+          <mat-error>必須入力です</mat-error>
         </mat-form-field>
         <mat-form-field>
           <mat-label>夜食</mat-label>
-          <input type="text" matInput formControlName="dinner" />
+          <input
+            type="text"
+            matInput
+            formControlName="dinner"
+            autocomplete="off"
+          />
+          <mat-error>必須入力です</mat-error>
         </mat-form-field>
       </div>
     </ng-container>

--- a/src/app/services/food.service.ts
+++ b/src/app/services/food.service.ts
@@ -22,7 +22,7 @@ export class FoodService {
     return this.db.collection<Food>('foods').valueChanges();
   }
 
-  getFoodId(id: string): Observable<Food> {
+  getFoodById(id: string): Observable<Food> {
     return this.db.doc<Food>(`foods/${id}`).valueChanges();
   }
 

--- a/src/app/services/my-menu.service.spec.ts
+++ b/src/app/services/my-menu.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { MyMenuService } from './my-menu.service';
+
+describe('MyMenuService', () => {
+  let service: MyMenuService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MyMenuService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/my-menu.service.ts
+++ b/src/app/services/my-menu.service.ts
@@ -1,0 +1,120 @@
+import { Injectable } from '@angular/core';
+import { AngularFirestore } from '@angular/fire/firestore';
+import {
+  MyMenu,
+  DayMenu,
+  DayMenuWithFood,
+  MyMenuWithFood,
+} from '@interfaces/my-menu';
+import { Observable, combineLatest } from 'rxjs';
+import { map, switchMap } from 'rxjs/operators';
+import { FoodService } from './food.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MyMenuService {
+  dayOfWeeks: string[] = ['日', '月', '火', '水', '木', '金', '土'];
+
+  constructor(private db: AngularFirestore, private foodService: FoodService) {}
+
+  createMyMenu(myMenu: Omit<MyMenu, 'myMenuId'>): Promise<void> {
+    const myMenuId = this.db.createId();
+    return this.db.doc(`userMenus/${myMenuId}`).set({
+      myMenuId,
+      ...myMenu,
+    });
+  }
+
+  updateMyMenu() {}
+
+  deleteMyMenu() {}
+
+  getMyMenuById(userId: string): Observable<MyMenu[]> {
+    return this.db
+      .collection<MyMenu>('userMenus', (ref) => {
+        return ref.where('creatorId', '==', userId);
+      })
+      .valueChanges();
+  }
+
+  getMyMenuWithFood(userId: string): Observable<MyMenuWithFood> {
+    return this.getMyMenuById(userId).pipe(
+      map((myMenus: MyMenu[]) => myMenus[0]),
+      map((myMenu: MyMenu) => myMenu.day),
+      map((day) => {
+        const days: DayMenu[] = [
+          day.sunday,
+          day.monday,
+          day.tuesday,
+          day.wednesday,
+          day.thursday,
+          day.friday,
+          day.saturday,
+        ];
+        return days;
+      }),
+      switchMap(
+        (dayMenus: DayMenu[]): Observable<MyMenuWithFood> => {
+          const dayMenuWithFoods$: Observable<DayMenuWithFood>[] = dayMenus.map(
+            (dayMenu: DayMenu) => {
+              return combineLatest([
+                this.foodService.getFoodById(dayMenu.breakfastId),
+                this.foodService.getFoodById(dayMenu.lunchId),
+                this.foodService.getFoodById(dayMenu.dinnerId),
+              ]).pipe(
+                map(([breakfast, lunch, dinner]) => {
+                  return {
+                    breakfast,
+                    lunch,
+                    dinner,
+                    dayOfWeek: '',
+                  };
+                })
+              );
+            }
+          );
+
+          return combineLatest(dayMenuWithFoods$).pipe(
+            map((dayMenuWithFoods: DayMenuWithFood[]) => {
+              for (let i = 0; i < 7; i++) {
+                dayMenuWithFoods[i].dayOfWeek = this.dayOfWeeks[i];
+              }
+              return {
+                sundayFood: dayMenuWithFoods[0],
+                mondayFood: dayMenuWithFoods[1],
+                tuesdayFood: dayMenuWithFoods[2],
+                wednesdayFood: dayMenuWithFoods[3],
+                thursdayFood: dayMenuWithFoods[4],
+                fridayFood: dayMenuWithFoods[5],
+                saturdayFood: dayMenuWithFoods[6],
+              };
+            })
+          );
+        }
+      )
+    );
+  }
+
+  getTodayMenu(userId: string): Observable<DayMenuWithFood> {
+    return this.getMyMenuWithFood(userId).pipe(
+      map((myMenuWithFood: MyMenuWithFood) => {
+        const weekMenu: DayMenuWithFood[] = [
+          myMenuWithFood.sundayFood,
+          myMenuWithFood.mondayFood,
+          myMenuWithFood.tuesdayFood,
+          myMenuWithFood.wednesdayFood,
+          myMenuWithFood.thursdayFood,
+          myMenuWithFood.fridayFood,
+          myMenuWithFood.saturdayFood,
+        ];
+        return weekMenu;
+      }),
+      map((dayMenuWithFoods: DayMenuWithFood[]) => {
+        const today = new Date();
+        const dayOfWeek = today.getDay();
+        return dayMenuWithFoods[dayOfWeek];
+      })
+    );
+  }
+}

--- a/src/app/services/user.service.ts
+++ b/src/app/services/user.service.ts
@@ -11,18 +11,18 @@ export class UserService {
     private storage: AngularFireStorage
   ) {}
 
-  changeUserName(userId: string, name: string) {
+  changeUserName(userId: string, name: string): Promise<void> {
     return this.db.doc(`users/${userId}`).update({
       name,
     });
   }
 
-  async changeUserAvater(userId: string, message: string) {
+  async changeUserAvater(userId: string, message: string): Promise<void> {
     const result = await this.storage
       .ref(`users/${userId}`)
       .putString(message, 'data_url');
     const avaterURL = await result.ref.getDownloadURL();
-    this.db.doc(`users/${userId}`).update({
+    return this.db.doc(`users/${userId}`).update({
       avaterURL,
     });
   }

--- a/src/app/setting/setting/setting.component.ts
+++ b/src/app/setting/setting/setting.component.ts
@@ -39,9 +39,9 @@ export class SettingComponent implements OnInit {
     });
   }
 
-  chengeUserName() {
+  chengeUserName(): Promise<void> {
     const newUserName = this.nameForm.value;
-    this.userService
+    return this.userService
       .changeUserName(this.userId, newUserName)
       .then(() => {
         this.snackBar.open('変更されました', null, {
@@ -59,28 +59,28 @@ export class SettingComponent implements OnInit {
   fileChengeEvent(event: any): void {
     this.imageChengedEvent = event;
   }
-  imageCropped(event: ImageCroppedEvent) {
+  imageCropped(event: ImageCroppedEvent): void {
     this.croppedImage = event.base64;
   }
-  imageLoaded() {
+  imageLoaded(): void {
     console.log('画像が読み込まれました');
   }
-  cropperReady(sourceImageDimensions: Dimensions) {
+  cropperReady(sourceImageDimensions: Dimensions): void {
     console.log('操作できるようになりました', sourceImageDimensions);
   }
-  loadImageFailed(selectedImage) {
+  loadImageFailed(selectedImage): void {
     alert('画像の読み込みに失敗しました');
     selectedImage.value = '';
     this.imageChengedEvent = '';
   }
-  resetImage(selectedImage) {
+  resetImage(selectedImage): void {
     selectedImage.value = '';
     this.imageChengedEvent = '';
     this.croppedImage = '';
   }
 
-  chengeUserAvater(selectedImage) {
-    this.userService
+  chengeUserAvater(selectedImage): Promise<void> {
+    return this.userService
       .changeUserAvater(this.userId, this.croppedImage)
       .then(() => {
         this.snackBar.open('変更されました', null, {


### PR DESCRIPTION
fix #41 
以下のように実装しました。
ご確認のほどお願いします。
## 作業内容
- firestore.rules追加
- MyMenu Interface追加
- method名変更
- MyMenuService追加
- My献立作成機能(仮)追加
-> 今の段階ではユーザが検索したfoodではなく、手作業でfoodのIdを打ち込んでます。
- 献立画面に作成したMy献立表示
- ホーム画面に曜日ごとの献立表示

![27041a554f9bc8c3ec0e1da2fb9547f3](https://user-images.githubusercontent.com/63761544/84984844-9c9ccb00-b176-11ea-843d-e5c94cd8b4c5.gif)
